### PR TITLE
Fix: Allow match multiple for oneOf when allowUnknownProperties is true

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -345,6 +345,9 @@ function validateType(name, value, field, models, allowBlankTargets, disallowExt
             } else if(matchCount === 1) {
                 return createReturnObject();
             } else {
+                if(!disallowExtraProperties) {
+                    return createReturnObject();
+                }
                 var matchErrors = [];
                 matchErrors.push(new Error( name + "matches more than one entry in a oneOf."))
                 return createReturnObject(matchErrors, name);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "swagger-model-validator",
-  "version": "3.0.19",
+  "name": "swagger-model-validator-exp",
+  "version": "3.0.19.1",
   "description": "Validate incoming objects against Swagger Models.",
   "keywords": [
     "Swagger",


### PR DESCRIPTION
Context:
OneOf validation should be able to match multiple schemas when allowUnknownProperties is true. 

